### PR TITLE
[TASK] Remove warning and error from .editorconfig.dist

### DIFF
--- a/templates/editorconfig.dist
+++ b/templates/editorconfig.dist
@@ -24,16 +24,12 @@ indent_style = tab
 [*.rst]
 indent_size = 3
 
-# MD-Files
-[*.md]
-indent_size = 4
-
 # YAML-Files
 [*.{yaml,yml}]
 indent_size = 2
 
 # package.json
-[{package.json}]
+[package.json]
 indent_size = 2
 
 # TypoScript


### PR DESCRIPTION
PhpStorm complained about the following configurations:
- [*.md]: This option duplicates parent and can be removed
- [{package.json}]: This pattern enumeration contains less than two patterns,
  so braces should be removed