### PR TITLE
[BUGFIX] Avoid yoda-style conditions in PHP

### DIFF
--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -91,6 +91,7 @@ EOF;
         'single_trait_insert_per_statement' => true,
         'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'whitespace_after_comma_in_array' => true,
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
     ];
 
     public function __construct(string $name = 'TYPO3')


### PR DESCRIPTION
This commit streamlines the PHP-CS-Fixer rules with TYPO3/typo3@0fb53e0 which added configuration to disable yoda-style conditions.