### PR TITLE
Avoid yoda-style conditions in PHP

### DIFF
--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -91,6 +91,7 @@ EOF;
         'single_trait_insert_per_statement' => true,
         'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'whitespace_after_comma_in_array' => true,
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
     ];
 
     public function __construct(string $name = 'TYPO3')


### PR DESCRIPTION
The core team agreed on not using yoda-style conditions in PHP. An
appropriate PHP-CS-Fixer rule to explicitly disable yoda-style has
been added to ensure that this coding style is respected. Additionally,
all yoda-style conditions have been transformed to normal conditions.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/75005/