### PR TITLE
[BUGFIX] Remove modernize_strpos

### DIFF
--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -54,7 +54,6 @@ EOF;
         'function_typehint_space' => true,
         'lowercase_cast' => true,
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
-        'modernize_strpos' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,
         'new_with_braces' => true,

--- a/tests/Unit/CsFixerConfigTest.php
+++ b/tests/Unit/CsFixerConfigTest.php
@@ -26,7 +26,7 @@ class CsFixerConfigTest extends TestCase
         $config = CsFixerConfig::create();
         self::assertInstanceOf(CsFixerConfig::class, $config);
         self::assertTrue($config->getRiskyAllowed());
-        self::assertCount(52, $config->getRules());
+        self::assertCount(51, $config->getRules());
     }
 
     public function testAddRules(): void


### PR DESCRIPTION
This rule breaks code on PHP versions below 8.0 and will be removed
again until PHP requirements are raised.