### PR TITLE
[TASK] Reduce PHPStan tests

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: typo3-coding-standards
 type: php
 docroot: ""
-php_version: "7.2"
+php_version: "8.1"
 webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -73,11 +73,14 @@ nodejs_version: "16"
 # commands are executed.
 
 # composer_version: "2"
-# if composer_version:"2" it will use the most recent composer v2
-# It can also be set to "1", to get most recent composer v1
-# or "" for the default v2 created at release time.
-# It can be set to any existing specific composer version.
-# After first project 'ddev start' this will not be updated until it changes
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to select a minor version for example "2.2" which will
+# install the latest release of that branch. Alternatively, an explicit Composer
+# version may be specified, for example "1.0.22". Finally, it is also possible
+# to use one of the key words "stable", "preview" or "snapshot" see Composer
+# documentation.
+# To reinstall Composer after the image was built, run "ddev debug refresh".
 
 # nodejs_version: "16"
 # change from the default system Node.js version to another supported version, like 12, 14, 17, 18.
@@ -98,6 +101,8 @@ nodejs_version: "16"
 
 # upload_dir: custom/upload/dir
 # would set the destination path for ddev import-files to <docroot>/custom/upload/dir
+# When mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dir don't have to be synced into mutagen
 
 # working_dir:
 #   web: /var/www/html
@@ -203,6 +208,33 @@ nodejs_version: "16"
 # default_container_timeout: 120
 # The default time that ddev waits for all containers to become ready can be increased from
 # the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
 
 # Many ddev commands can be extended to run tasks before or after the
 # ddev command is executed, for example "post-start", "post-import-db",

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -180,9 +180,6 @@ jobs:
       matrix:
         php-version:
           - '7.2'
-          - '7.3'
-          - '7.4'
-          - '8.0'
           - '8.1'
           - 'latest'
         dependencies:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	level: max
+	phpVersion: 70200
 	treatPhpDocTypesAsCertain: false
 
 	paths:


### PR DESCRIPTION
Switch local development to PHP 8.1 and explicitly define PHP version
for PHPStan to 7.2. Also superfluous tests in CI are removed.