### PR TITLE
[TASK] Change PHP version for PHP CS job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -144,7 +144,7 @@ jobs:
           coverage: none
           extensions: intl, zip
           ini-values: memory_limit=-1, error_reporting=E_ALL, display_errors=On
-          php-version: latest
+          php-version: '8.1'
 
       - name: Composer Cache Vars
         id: composer-cache-vars


### PR DESCRIPTION
PHP CS Fixer isn't currently compatible with PHP > 8.1 so 8.1 is now
pinned for the PHP Coding Standards job.