### PR TITLE
[BUGFIX] Require a PHP-CS-Fixer version that support the PER standard

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,6 +133,39 @@ jobs:
     needs:
       - php_lint
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.0'
+          - '8.1'
+        dependencies:
+          - 'lowest'
+          - 'stable'
+          - 'highest'
+        experimental:
+          - false
+        include:
+          - php-version: 'latest'
+            dependencies: 'lowest'
+            experimental: true
+          - php-version: 'latest'
+            dependencies: 'stable'
+            experimental: true
+          - php-version: 'latest'
+            dependencies: 'highest'
+            experimental: true
+          - php-version: 'nightly'
+            dependencies: 'lowest'
+            experimental: true
+          - php-version: 'nightly'
+            dependencies: 'stable'
+            experimental: true
+          - php-version: 'nightly'
+            dependencies: 'highest'
+            experimental: true
 
     steps:
       - name: Checkout
@@ -144,7 +177,7 @@ jobs:
           coverage: none
           extensions: intl, zip
           ini-values: memory_limit=-1, error_reporting=E_ALL, display_errors=On
-          php-version: '8.1'
+          php-version: ${{ matrix.php-version }}
 
       - name: Composer Cache Vars
         id: composer-cache-vars
@@ -156,16 +189,31 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache-vars.outputs.dir }}
-          key: ${{ runner.os }}-composer-2-latest-${{ steps.composer-cache-vars.outputs.timestamp }}
+          key: ${{ runner.os }}-composer-2-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ steps.composer-cache-vars.outputs.timestamp }}
           restore-keys: |
-            ${{ runner.os }}-composer-2-latest-
+            ${{ runner.os }}-composer-2-${{ matrix.php-version }}-${{ matrix.dependencies }}-
+            ${{ runner.os }}-composer-2-${{ matrix.php-version }}-
             ${{ runner.os }}-composer-2-
             ${{ runner.os }}-composer-
 
+      - name: Handle lowest dependencies update
+        if: contains(matrix.dependencies, 'lowest')
+        run: echo "COMPOSER_UPDATE_FLAGS=$COMPOSER_UPDATE_FLAGS --prefer-lowest" >> $GITHUB_ENV
+
+      - name: Allow alpha releases for latest-deps builds to catch problems earlier
+        if: contains(matrix.dependencies, 'highest')
+        run: composer config minimum-stability alpha
+
+      - name: Set platform.php for nightly
+        if: ${{ matrix.php-version == 'nightly' }}
+        run: |
+          composer config platform.php 8.1.99
+
       - name: Install dependencies
-        run: composer install ${{ env.COMPOSER_INSTALL_FLAGS }} ${{ env.COMPOSER_FLAGS }}
+        run: composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_INSTALL_FLAGS }} ${{ env.COMPOSER_FLAGS }}
 
       - name: Validation of coding standards for PHP files
+        continue-on-error: ${{ matrix.experimental }}
         run: composer ci:php:cs
 
   php_stan:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"require": {
 		"php": "^8.0",
 		"ext-json": "*",
-		"friendsofphp/php-cs-fixer": "^3.0",
+		"friendsofphp/php-cs-fixer": "^3.11.0",
 		"symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
 		"symfony/filesystem": "^4.4 || ^5.0 || ^6.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"require": {
 		"php": "^8.0",
 		"ext-json": "*",
-		"friendsofphp/php-cs-fixer": "^3.11.0",
+		"friendsofphp/php-cs-fixer": "^3.11",
 		"symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
 		"symfony/filesystem": "^4.4 || ^5.0 || ^6.0"
 	},


### PR DESCRIPTION
We recently switch from PSR-2 to PER as our base coding standard.

As this standard got introduced in PHP-CS-Fixer 3.11.0, we need that have this version as the minimum required version.

Fixes #82