### PR TITLE
[BUGFIX] Restore PHP 7.2 compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -213,6 +213,8 @@ jobs:
         run: composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_INSTALL_FLAGS }} ${{ env.COMPOSER_FLAGS }}
 
       - name: Validation of coding standards for PHP files
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
         continue-on-error: ${{ matrix.experimental }}
         run: composer ci:php:cs
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"require": {
 		"php": "^7.2 || ^8.0",
 		"ext-json": "*",
-		"friendsofphp/php-cs-fixer": "^3.11",
+		"friendsofphp/php-cs-fixer": "^3.0",
 		"symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
 		"symfony/filesystem": "^4.4 || ^5.0 || ^6.0"
 	},

--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -41,7 +41,7 @@ EOF;
      */
     protected static $typo3Rules = [
         '@DoctrineAnnotation' => true,
-        '@PER' => true,
+        '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
         'blank_line_after_opening_tag' => true,
         'braces' => ['allow_single_line_closure' => true],
@@ -68,11 +68,10 @@ EOF;
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,
-        'no_trailing_comma_in_singleline' => true,
+        'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_nullsafe_operator' => true,
         'no_whitespace_in_blank_line' => true,
         'ordered_imports' => true,
         'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
@@ -90,7 +89,7 @@ EOF;
         'single_line_comment_style' => ['comment_types' => ['hash']],
         'single_trait_insert_per_statement' => true,
         'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'whitespace_after_comma_in_array' => true,
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
     ];
 

--- a/tests/Unit/CsFixerConfigTest.php
+++ b/tests/Unit/CsFixerConfigTest.php
@@ -29,7 +29,7 @@ final class CsFixerConfigTest extends TestCase
         $csFixerConfig = CsFixerConfig::create();
         self::assertInstanceOf(CsFixerConfig::class, $csFixerConfig);
         self::assertTrue($csFixerConfig->getRiskyAllowed());
-        self::assertCount(52, $csFixerConfig->getRules());
+        self::assertCount(51, $csFixerConfig->getRules());
     }
 
     public function testAddRules(): void


### PR DESCRIPTION
This patch reverts with PHP-CS-Fixer for PHP 7.2 incompatible changes again.