### PR TITLE
[BUGFIX] Skip system/settings.php

### DIFF
--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -107,6 +107,9 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
                 'var',
                 'vendor',
             ])
+            ->notPath([
+                'config/system/settings.php',
+            ])
         ;
 
         return $static;


### PR DESCRIPTION
The config/system/settings.php is commonly updated through the TYPO3 backend and exported accordingly. Thus coding style standards can and should not be applied here.