### PR TITLE
[FEATURE] Add support for Symfony v7 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
 		"php": "^8.1",
 		"ext-json": "*",
 		"friendsofphp/php-cs-fixer": "^3.16",
-		"symfony/console": "^5.4 || ^6.0",
-		"symfony/filesystem": "^5.4 || ^6.0"
+		"symfony/console": "^5.4 || ^6.0 || ^7.0",
+		"symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
 	},
 	"require-dev": {
 		"composer/package-versions-deprecated": "^1.11.99.5",

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
 		"php": "^8.1",
 		"ext-json": "*",
 		"friendsofphp/php-cs-fixer": "^3.16",
-		"symfony/console": "^5.4 || ^6.0 || ^7.0",
-		"symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
+		"symfony/console": "^5.4 || ^6.4 || ^7.0",
+		"symfony/filesystem": "^5.4 || ^6.4 || ^7.0"
 	},
 	"require-dev": {
 		"composer/package-versions-deprecated": "^1.11.99.5",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		"keradus/cli-executor": "^1.5",
 		"maglnet/composer-require-checker": "*",
 		"nikic/php-parser": "^4.15.5",
-		"overtrue/phplint": "^3.1.1",
+		"overtrue/phplint": "^9.0",
 		"phpstan/extension-installer": "^1.3.1",
 		"phpstan/phpstan-deprecation-rules": "^1.1.3",
 		"phpstan/phpstan-phpunit": "^1.3.12",

--- a/src/Console/Command/SetupCommand.php
+++ b/src/Console/Command/SetupCommand.php
@@ -29,21 +29,13 @@ use TYPO3\CodingStandards\Setup;
  */
 final class SetupCommand extends Command
 {
-    /**
-     * @var string
-     */
-    protected static $defaultName = 'setup';
-
-    /**
-     * @var string
-     */
-    protected static $defaultDescription = 'Setting up the TYPO3 rule sets for an extension or a project';
-
     protected function configure(): void
     {
         parent::configure();
 
         $this
+            ->setName('setup')
+            ->setDescription('Setting up the TYPO3 rule sets for an extension or a project')
             ->addArgument('type', InputArgument::OPTIONAL, sprintf(
                 'Type to setup, valid types are <comment>["%s"]</comment>. If not set, the detection is automatic',
                 implode('","', Setup::VALID_TYPES)

--- a/src/Console/Command/UpdateCommand.php
+++ b/src/Console/Command/UpdateCommand.php
@@ -26,15 +26,11 @@ use TYPO3\CodingStandards\Setup;
  */
 final class UpdateCommand extends Command
 {
-    /**
-     * @var string
-     */
-    protected static $defaultName = 'update';
-
-    /**
-     * @var string
-     */
-    protected static $defaultDescription = 'Update the TYPO3 rule sets';
+    protected function configure(): void
+    {
+        $this->setName('update');
+        $this->setDescription('Update the TYPO3 rule sets');
+    }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/tests/Console/Style/SimpleStyle.php
+++ b/tests/Console/Style/SimpleStyle.php
@@ -448,7 +448,7 @@ class SimpleStyle extends OutputStyle
     private function createBlock(iterable $messages, string $type = null, string $style = null, string $prefix = ' ', bool $padding = false, bool $escape = false): array
     {
         $indentLength = 0;
-        $prefixLength = Helper::strlenWithoutDecoration($this->getFormatter(), $prefix);
+        $prefixLength = Helper::removeDecoration($this->getFormatter(), $prefix);
         $lines = [];
 
         if ($type !== null) {

--- a/tests/Console/Style/SimpleStyle.php
+++ b/tests/Console/Style/SimpleStyle.php
@@ -251,7 +251,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function ask($question, $default = null, $validator = null)
+    public function ask(string $question, string $default = null, callable $validator = null): mixed
     {
         $question = new Question($question, $default);
         $question->setValidator($validator);
@@ -262,7 +262,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function askHidden($question, $validator = null)
+    public function askHidden(string $question, callable $validator = null): mixed
     {
         $question = new Question($question);
 
@@ -275,7 +275,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function confirm($question, $default = true)
+    public function confirm(string $question, bool $default = true): bool
     {
         return $this->askQuestion(new ConfirmationQuestion($question, $default));
     }
@@ -283,7 +283,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function choice($question, array $choices, $default = null)
+    public function choice(string $question, array $choices, mixed $default = null): mixed
     {
         if ($default !== null) {
             $values = array_flip($choices);
@@ -296,7 +296,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function progressStart($max = 0): void
+    public function progressStart(int $max = 0): void
     {
         $this->progressBar = $this->createProgressBar($max);
         $this->progressBar->start();
@@ -305,7 +305,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function progressAdvance($step = 1): void
+    public function progressAdvance(int $step = 1): void
     {
         $this->getProgressBar()->advance($step);
     }
@@ -323,7 +323,7 @@ class SimpleStyle extends OutputStyle
     /**
      * @inheritDoc
      */
-    public function createProgressBar($max = 0)
+    public function createProgressBar(int $max = 0): ProgressBar
     {
         $progressBar = parent::createProgressBar($max);
 

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -21,10 +21,12 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use TYPO3\CodingStandards\Console\Application;
 use TYPO3\CodingStandards\Console\Command\SetupCommand;
+use TYPO3\CodingStandards\Console\Command\UpdateCommand;
 use TYPO3\CodingStandards\Tests\Unit\TestCase;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(Application::class)]
 #[\PHPUnit\Framework\Attributes\UsesClass(SetupCommand::class)]
+#[\PHPUnit\Framework\Attributes\UsesClass(UpdateCommand::class)]
 final class ApplicationTest extends TestCase
 {
     public function testApplication(): void

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -34,7 +34,7 @@ final class ApplicationTest extends TestCase
 
         $applicationTester = new ApplicationTester($application);
 
-        self::assertSame(0, $applicationTester->run([]));
+        self::assertSame(0, $applicationTester->run(['--no-ansi' => true]));
         self::assertStringContainsString(
             'TYPO3 Coding Standards ' . Application::VERSION,
             $applicationTester->getDisplay()

--- a/tests/Unit/Console/Command/CommandTest.php
+++ b/tests/Unit/Console/Command/CommandTest.php
@@ -21,10 +21,12 @@ use Symfony\Component\Console\Input\ArrayInput;
 use TYPO3\CodingStandards\Console\Application;
 use TYPO3\CodingStandards\Console\Command\Command;
 use TYPO3\CodingStandards\Console\Command\SetupCommand;
+use TYPO3\CodingStandards\Console\Command\UpdateCommand;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(Command::class)]
 #[\PHPUnit\Framework\Attributes\UsesClass(Application::class)]
 #[\PHPUnit\Framework\Attributes\UsesClass(SetupCommand::class)]
+#[\PHPUnit\Framework\Attributes\UsesClass(UpdateCommand::class)]
 final class CommandTest extends CommandTestCase
 {
     private ?CommandTestImplementation $commandTestImplementation = null;

--- a/tests/Unit/Console/Command/SetupCommandTest.php
+++ b/tests/Unit/Console/Command/SetupCommandTest.php
@@ -21,9 +21,11 @@ use RuntimeException;
 use TYPO3\CodingStandards\Console\Application;
 use TYPO3\CodingStandards\Console\Command\Command;
 use TYPO3\CodingStandards\Console\Command\SetupCommand;
+use TYPO3\CodingStandards\Console\Command\UpdateCommand;
 use TYPO3\CodingStandards\Setup;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(SetupCommand::class)]
+#[\PHPUnit\Framework\Attributes\CoversClass(UpdateCommand::class)]
 #[\PHPUnit\Framework\Attributes\UsesClass(Application::class)]
 #[\PHPUnit\Framework\Attributes\UsesClass(Command::class)]
 #[\PHPUnit\Framework\Attributes\UsesClass(Setup::class)]

--- a/tests/Unit/Smoke/AbstractCliTestCase.php
+++ b/tests/Unit/Smoke/AbstractCliTestCase.php
@@ -49,7 +49,7 @@ abstract class AbstractCliTestCase extends TestCase
     {
         self::assertMatchesRegularExpression(
             '/^TYPO3 Coding Standards ' . Application::VERSION . '$/',
-            self::executeCliCommand('--version')->getOutput()
+            self::executeCliCommand('--version --no-ansi')->getOutput()
         );
     }
 


### PR DESCRIPTION
This PR extends version constraints to support Symfony v7 components. In addition, the `overtrue/phplint` package was updated to a more recent version that supports Symfony v7 as well.

Next to the version constraint updates, the following code modifications were necessary:

* Run console commands without ANSI colors during testing by using the `--no-ansi` command option
* Replace removed `Helper::strlenWithoutDecoration()` with `Helper::removeDecoration()`
* Add parameter types and return types to `SimpleStyle`
* Avoid using `defaultName` and `defaultDescription` properties in console commands