### PR TITLE
[TASK] Add PHP 8.3 to version matrix in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,6 +140,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
         dependencies:
           - 'lowest'
           - 'stable'
@@ -229,6 +230,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
           - 'latest'
         dependencies:
           - 'lowest'
@@ -320,6 +322,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
           - 'latest'
         composer-version:
           - '2'


### PR DESCRIPTION
This PR extends version matrix in CI workflow to include PHP 8.3 as well.