### PR TITLE
[BUGFIX] Be more lenient when checking the output in a string

### DIFF
--- a/tests/Unit/Smoke/AbstractCliTestCase.php
+++ b/tests/Unit/Smoke/AbstractCliTestCase.php
@@ -56,14 +56,12 @@ abstract class AbstractCliTestCase extends TestCase
     public function testSetup(): void
     {
         $command = (new Application())->find('setup');
-
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['--target-dir' => self::getRootPath()]);
 
-        self::assertSame(
-            $commandTester->getDisplay(),
-            self::executeCliCommand('setup')->getOutput()
-        );
+        $commandTester->execute(['--target-dir' => self::getRootPath()]);
+        $output = self::executeCliCommand('setup')->getOutput();
+
+        self::assertStringContainsString('[ERROR] A .php-cs-fixer.dist.php file already exists,', $output);
     }
 
     public function testSetupHelp(): void


### PR DESCRIPTION
We don't need to test the particular formatting details of an error message - it suffices to test that the error message is there.