### PR TITLE
[TASK] Do not run PHPStan with unstable PHP versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -231,23 +231,12 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - 'latest'
         dependencies:
           - 'lowest'
           - 'stable'
           - 'highest'
         experimental:
           - false
-        include:
-          - php-version: 'nightly'
-            dependencies: 'lowest'
-            experimental: true
-          - php-version: 'nightly'
-            dependencies: 'stable'
-            experimental: true
-          - php-version: 'nightly'
-            dependencies: 'highest'
-            experimental: true
 
     steps:
       - name: Checkout
@@ -285,10 +274,6 @@ jobs:
       - name: Allow alpha releases for latest-deps builds to catch problems earlier
         if: contains(matrix.dependencies, 'highest')
         run: composer config minimum-stability alpha
-
-      - name: Ignore platfrom requirements for nightly
-        if: ${{ matrix.php-version == 'nightly' }}
-        run: echo "COMPOSER_UPDATE_FLAGS=$COMPOSER_UPDATE_FLAGS --ignore-platform-reqs" >> $GITHUB_ENV
 
       - name: Install dependencies without deprecation rules
         run: |


### PR DESCRIPTION
To catch problems in our code and in in association with the used libraries, we don't need to check with unstable PHP versions.

This also avoids failures that are unrelated to our code.