### PR TITLE
[TASK] Sync php-cs-fixer rules with the latest TYPO3 Core version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"require": {
 		"php": "^8.1",
 		"ext-json": "*",
-		"friendsofphp/php-cs-fixer": "^3.49",
+		"friendsofphp/php-cs-fixer": "^3.88.2",
 		"symfony/console": "^6.4 || ^7.0",
 		"symfony/filesystem": "^6.4 || ^7.0"
 	},

--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -41,17 +41,17 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
      */
     protected static $typo3Rules = [
         '@DoctrineAnnotation' => true,
-        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
-        '@PER-CS1.0' => true,
+        // @todo: Switch to @PER-CS2x0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1x0' => true,
         'array_indentation' => true,
         'array_syntax' => ['syntax' => 'short'],
         'cast_spaces' => ['space' => 'none'],
-        // @todo: Can be dropped once we enable @PER-CS2.0
+        // @todo: Can be dropped once we enable @PER-CS2x0
         'concat_space' => ['spacing' => 'one'],
         'declare_equal_normalize' => ['space' => 'none'],
         'declare_parentheses' => true,
         'dir_constant' => true,
-        // @todo: Can be dropped once we enable @PER-CS2.0
+        // @todo: Can be dropped once we enable @PER-CS2x0
         'function_declaration' => [
             'closure_fn_spacing' => 'none',
         ],
@@ -59,7 +59,7 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
         'type_declaration_spaces' => true,
         'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
         'list_syntax' => ['syntax' => 'short'],
-        // @todo: Can be dropped once we enable @PER-CS2.0
+        // @todo: Can be dropped once we enable @PER-CS2x0
         'method_argument_space' => true,
         'modernize_strpos' => true,
         'modernize_types_casting' => true,
@@ -112,11 +112,12 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'protected_to_private' => true,
         'return_type_declaration' => ['space_before' => 'none'],
         'single_quote' => true,
         'single_space_around_construct' => true,
         'single_line_comment_style' => ['comment_types' => ['hash']],
-        // @todo: Can be dropped once we enable @PER-CS2.0
+        // @todo: Can be dropped once we enable @PER-CS2x0
         'single_line_empty_body' => true,
         'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'whitespace_after_comma_in_array' => ['ensure_single_space' => true],


### PR DESCRIPTION
Synced with the following TYPO3 Core changes:

- https://github.com/TYPO3/typo3/commit/cc1708bc1bc3454d928845c5d8f768b42bee4fc3 Rename @PER-CS1.0 to @PER-CS1x0 (and @PER-CS2.0 to @PER-CS2x0 in comments) following the php-cs-fixer 3.88.0 ruleset rename. Bumps php-cs-fixer requirement to ^3.88.2.

- https://github.com/TYPO3/typo3/commit/d7d47c5f2d74392a47822c97f279a5e7069a78f0 Add 'protected_to_private' rule to enforce private visibility where protected is not required.