### PR TITLE
[TASK] Ensure this package gets installed as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 		"typo3",
 		"cms",
 		"code style",
+		"dev",
 		"editorconfig",
 		"php-cs-fixer"
 	],


### PR DESCRIPTION
The keyword "dev" [1] causes Composer to warn if this package gets installed as a production dependency instead of as a development dependency.

This supports developers in installing this package correctly.

[1] https://getcomposer.org/doc/04-schema.md#keywords